### PR TITLE
Added default spec helper file.

### DIFF
--- a/rails-api-template.rb
+++ b/rails-api-template.rb
@@ -143,6 +143,9 @@ require "action_controller/railtie"
 
   run "spring stop"
   generate "rspec:install"
+  remove_file "spec/spec_helper.rb"
+  copy_file "spec_helper.rb", "spec/spec_helper.rb"
+
   run "guard init"
 
   # Health Check route

--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -1,0 +1,29 @@
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    # Only allow the expectation syntax
+    expectations.syntax = :expect
+
+    # Include custom matcher descriptions in output
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    # Validate mocked objects
+    mocks.verify_partial_doubles = true
+  end
+
+  # Disable monkey patching for describe
+  config.expose_dsl_globally = false
+  config.disable_monkey_patching!
+
+  if config.files_to_run.one?
+    # Use the documentation formatter for detailed output
+    config.default_formatter = 'doc'
+  end
+
+  # Run specs in random order to surface order dependencies
+  config.order = :random
+
+  # Seed global randomization in this process using the `--seed` CLI option
+  Kernel.srand config.seed
+end


### PR DESCRIPTION
- Only allow the `expect` syntax
- No monkey patching
- Run specs in random order
- Other nice defaults
